### PR TITLE
Add tmc

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -9,3 +9,6 @@ downstream_repos:
   insightsengineering/scda:
     repo: insightsengineering/scda
     host: https://github.com
+  insightsengineering/teal.modules.clinical:
+    repo: insightsengineering/teal.modules.clinical
+    host: https://github.com


### PR DESCRIPTION
Removes `teal.modules.clinical` as a downstream dependency.

Part of https://github.com/insightsengineering/teal.modules.clinical/pull/659
