### PR TITLE
update scda.2022 for teal and chevron

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -36,3 +36,9 @@ downstream_repos:
   insightsengineering/teal.osprey:
     repo: insightsengineering/teal.osprey
     host: https://github.com
+  insightsengineering/teal.modules.clinical:
+    repo: insightsengineering/teal.modules.clinical
+    host: https://github.com
+  insightsengineering/chevron:
+    repo: insightsengineering/chevron
+    host: https://github.com


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/issues/760 don't merge until chevron and tmc are ready

@edelarua I merged the other PRs in to main and made main stable so there's only chevron and tmc left (along with corresponding PRs in scda.2021 and scda.2022)